### PR TITLE
/configfs-tsm Use Java 8 source & target

### DIFF
--- a/configfs-tsm/pom.xml
+++ b/configfs-tsm/pom.xml
@@ -24,8 +24,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Fixes
[ERROR] COMPILATION ERROR :
[INFO] ------------------------------------------------------------- [ERROR] Source option 7 is no longer supported. Use 8 or later. [ERROR] Target option 7 is no longer supported. Use 8 or later.

Java 7 source/target is not supported anymore.
Tested with Java 21 and Java 25.